### PR TITLE
Enable system colour mode in Chakra provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ const apolloClient = createApolloClient();
 
 export const App = (): JSX.Element => (
   <ApolloProvider client={apolloClient}>
-    <CustomChakraProvider enableSystem={false}>
+    <CustomChakraProvider>
       <Container maxWidth={'4xl'}>
         <CvContainer />
       </Container>


### PR DESCRIPTION
## Summary
Enables system colour mode detection in the Chakra UI provider by removing the explicit `enableSystem={false}` prop. This allows the application to automatically detect and respect the user's system-wide dark/light mode preference.

## Changes
- Removed `enableSystem={false}` prop from `CustomChakraProvider` in `src/App.tsx`
- The provider now defaults to `enableSystem={true}`, automatically detecting system colour scheme

## Benefits
- Better user experience by respecting system preferences
- Automatic dark/light mode switching based on OS settings
- Reduces manual theme switching for users

🤖 Generated with [Claude Code](https://claude.ai/code)