### PR TITLE
Add Google analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,28 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="shortcut icon" href="/src/favicon.ico">
-    <link href="//fonts.googleapis.com/css?family=Roboto:300,400,600&display=swap" rel="stylesheet">
+    <link rel="shortcut icon" href="/src/favicon.ico" />
+    <link
+      href="//fonts.googleapis.com/css?family=Roboto:300,400,600&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CV: Matt Calthrop</title>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-9QDZHSX0GQ"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', 'G-9QDZHSX0GQ');
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
Add Google Analytics tracking to the CV application to monitor site usage and visitor analytics.

## Changes
- Added Google Analytics (gtag.js) script to `index.html` with tracking ID `G-9QDZHSX0GQ`
- Updated HTML formatting for consistency (doctype, link formatting)
- Analytics will track page views and user interactions on the CV site

## Test Plan
- [ ] Verify Google Analytics script loads correctly in browser dev tools
- [ ] Confirm tracking events are sent to Google Analytics dashboard
- [ ] Test that the CV application continues to function normally with analytics enabled