### PR TITLE
Add @vercel/speed-insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@apollo/client": "4.0.3",
     "@apollo/client-integration-nextjs": "0.13.0",
+    "@apollo/client": "4.0.3",
     "@chakra-ui/react": "3.25.0",
     "@emotion/react": "11.14.0",
+    "@vercel/speed-insights": "1.2.0",
     "graphql": "16.11.0",
     "next-themes": "0.4.6",
     "next": "15.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@emotion/react':
         specifier: 11.14.0
         version: 11.14.0(@types/react@19.1.12)(react@19.1.1)
+      '@vercel/speed-insights':
+        specifier: 1.2.0
+        version: 1.2.0(next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       graphql:
         specifier: 16.11.0
         version: 16.11.0
@@ -1381,6 +1384,29 @@ packages:
   '@typescript-eslint/visitor-keys@8.41.0':
     resolution: {integrity: sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vercel/speed-insights@1.2.0':
+    resolution: {integrity: sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -5550,6 +5576,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.41.0
       eslint-visitor-keys: 4.2.1
+
+  '@vercel/speed-insights@1.2.0(next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+    optionalDependencies:
+      next: 15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,10 +36,8 @@ const RootLayout = ({ children }: PropsWithChildren): React.JSX.Element => (
       />
     </head>
     <body>
-      <ChakraWrapper>
-        {children}
-        <SpeedInsights />
-      </ChakraWrapper>
+      <ChakraWrapper>{children}</ChakraWrapper>
+      <SpeedInsights />
     </body>
   </html>
 );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { ChakraWrapper } from '@/app/chakra-wrapper';
 import type { PropsWithChildren } from 'react';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 export const metadata: Metadata = {
   title: 'CV: Matt Calthrop',
@@ -35,7 +36,10 @@ const RootLayout = ({ children }: PropsWithChildren): React.JSX.Element => (
       />
     </head>
     <body>
-      <ChakraWrapper>{children}</ChakraWrapper>
+      <ChakraWrapper>
+        {children}
+        <SpeedInsights />
+      </ChakraWrapper>
     </body>
   </html>
 );


### PR DESCRIPTION
Adds Vercel Speed Insights to track application performance metrics.

## Changes
- Added `@vercel/speed-insights` dependency
- Integrated `<SpeedInsights />` component in the root layout

This will provide performance monitoring and insights when the application is deployed on Vercel.