### PR TITLE
Optimise GQL query caching

### DIFF
--- a/src/graphql/createApolloClient.tsx
+++ b/src/graphql/createApolloClient.tsx
@@ -20,7 +20,7 @@ export const { getClient, query, PreloadQuery } = registerApolloClient(
           // you can pass additional options that should be passed to `fetch` here,
           // e.g. Next.js-related `fetch` options regarding caching and revalidation
           // see https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options
-          cache: 'no-store',
+          next: { revalidate: 60 },
         },
       }),
     }),

--- a/src/graphql/createApolloClient.tsx
+++ b/src/graphql/createApolloClient.tsx
@@ -20,7 +20,7 @@ export const { getClient, query, PreloadQuery } = registerApolloClient(
           // you can pass additional options that should be passed to `fetch` here,
           // e.g. Next.js-related `fetch` options regarding caching and revalidation
           // see https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options
-          next: { revalidate: 60 },
+          next: { revalidate: 60 }, // Allow for Contentful data to be updated
         },
       }),
     }),


### PR DESCRIPTION
## Summary

Optimizes GraphQL query caching to improve performance while maintaining data freshness:

- **Enabled time-based revalidation**: Changed from `cache: 'no-store'` to `next: { revalidate: 60 }`
- **60-second cache duration**: GraphQL data will be cached for 60 seconds before being revalidated
- **Background updates**: Fresh data is fetched in the background after cache expiry
- **Reduced API calls**: Significantly fewer requests to Contentful GraphQL API

## Performance Benefits

- ⚡ **Faster page loads**: Subsequent requests within 60 seconds serve cached data
- 🔄 **Automatic freshness**: Data automatically updates every minute
- 📉 **Lower API usage**: Reduces load on Contentful API and improves rate limit compliance
- 🚀 **Better UX**: Instant page rendering for cached requests

## Technical Details

This change leverages Next.js App Router's built-in caching mechanism via the `fetch` options. The Apollo client will now use Next.js's cache instead of bypassing it entirely.

**Before**: Every request fetched fresh data (`cache: 'no-store'`)  
**After**: Data cached for 60 seconds with automatic background revalidation