### PR TITLE
Unskip skipped test, and fix

### DIFF
--- a/src/components/CvContainer/CvContainer.spec.tsx
+++ b/src/components/CvContainer/CvContainer.spec.tsx
@@ -1,5 +1,3 @@
-// @vitest-environment node
-
 import { render, screen } from '@/testUtils';
 import { CvContainer } from './CvContainer';
 import { fetchCvData } from './fetchCvData';
@@ -15,7 +13,7 @@ describe('CvContainer', () => {
     vi.clearAllMocks();
   });
 
-  it.skip('renders CvComponent when fetchCvData returns data', async () => {
+  it('renders CvComponent when fetchCvData returns data', async () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
     vi.mocked(fetchCvData).mockResolvedValue(mockCvData.cvCollection?.items[0]!);
 

--- a/src/mocks/graphql.ts
+++ b/src/mocks/graphql.ts
@@ -5,6 +5,10 @@ export const mockCvData: GetCvQuery = {
   cvCollection: {
     items: [
       {
+        sys: {
+          publishedAt: '2025-09-03T11:42:29.382Z',
+          publishedVersion: 42,
+        },
         image: { url: 'https://example.com/image.jpg' },
         overviewCollection: {
           items: [
@@ -51,7 +55,6 @@ export const mockCvData: GetCvQuery = {
         educationCollection: {
           items: [{ para: 'BSc Computer Science, University of Test' }],
         },
-        sys: {},
       },
     ],
   },


### PR DESCRIPTION
Fixes and re-enables the CvContainer test by:
- Removing the `@vitest-environment node` comment that was causing test environment conflicts
- Removing `it.skip()` to re-enable the test
- Adding missing `sys.publishedAt` and `sys.publishedVersion` fields to the mock data to match the GraphQL schema expectations

The test now passes successfully with proper mock data structure.