### PR TITLE
Add versioning strategy to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    versioning-strategy: increase
 
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
+    versioning-strategy: increase


### PR DESCRIPTION
## Summary
- Added `versioning-strategy: increase` to both GitHub Actions and npm ecosystems in Dependabot configuration
- This setting instructs Dependabot to use the "increase" strategy when updating dependency versions
- Helps create more targeted and consistent dependency updates across all package ecosystems

## Test plan
- [x] Verify Dependabot configuration syntax is valid
- [ ] Monitor next Dependabot run to ensure strategy is applied correctly
- [ ] Check that dependency updates follow the increased versioning strategy
- [ ] Validate no breaking changes in automated dependency updates

**Note:** This PR is in draft mode for review and testing before merge.

🤖 Generated with [Claude Code](https://claude.ai/code)