### PR TITLE
Remove unnecessary 'use client' statements

### DIFF
--- a/src/app/chakra-wrapper.tsx
+++ b/src/app/chakra-wrapper.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { PropsWithChildren } from 'react';
 import { CustomChakraProvider } from '@/components/chakra/provider';
 

--- a/src/components/Education/Education.tsx
+++ b/src/components/Education/Education.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Text, VStack } from '@chakra-ui/react';
 import type { Maybe, ParagraphFragment } from '@/graphql/generated/graphql';
 import { Section } from '@/components/Section';

--- a/src/components/Interests/Interests.tsx
+++ b/src/components/Interests/Interests.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Text, VStack } from '@chakra-ui/react';
 import type { Maybe, ParagraphFragment } from '@/graphql/generated/graphql';
 import { Section } from '@/components/Section';

--- a/src/components/OnTheWeb/OnTheWeb.tsx
+++ b/src/components/OnTheWeb/OnTheWeb.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Link } from '@chakra-ui/react';
 import type { Maybe, OnTheWebFragment } from '@/graphql/generated/graphql';
 import { Section } from '@/components/Section';

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { HStack, Image, Text, VStack } from '@chakra-ui/react';
 import type { Maybe, ParagraphFragment } from '@/graphql/generated/graphql';
 import { Section } from '@/components/Section';

--- a/src/components/PublicationData/PublicationData.tsx
+++ b/src/components/PublicationData/PublicationData.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { CvFragment } from '@/graphql/generated/graphql';
 import { Text } from '@chakra-ui/react';
 import { useEffect } from 'react';

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Box, Heading, VStack } from '@chakra-ui/react';
 
 type SectionProps = React.PropsWithChildren & {

--- a/src/components/WorkHistory/WorkHistory.tsx
+++ b/src/components/WorkHistory/WorkHistory.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Flex } from '@chakra-ui/react';
 import type { Maybe, WorkHistoryFragment } from '@/graphql/generated/graphql';
 import { Section } from '@/components/Section';

--- a/src/components/chakra/color-mode.tsx
+++ b/src/components/chakra/color-mode.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { IconButtonProps, SpanProps } from '@chakra-ui/react';
 import { ClientOnly, IconButton, Skeleton, Span } from '@chakra-ui/react';
 import { ThemeProvider, useTheme } from 'next-themes';

--- a/src/components/chakra/toaster.tsx
+++ b/src/components/chakra/toaster.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   Toaster as ChakraToaster,
   Portal,


### PR DESCRIPTION
Clean up unnecessary 'use client' directives that were not needed.

This PR removes 'use client' statements from 10 components that don't require it, because their parent component is already a client-rendered component:

- chakra-wrapper.tsx
- Education/Education.tsx 
- Interests/Interests.tsx
- OnTheWeb/OnTheWeb.tsx
- Overview/Overview.tsx
- PublicationData/PublicationData.tsx
- Section/Section.tsx
- WorkHistory/WorkHistory.tsx
- chakra/color-mode.tsx
- chakra/toaster.tsx

These components can be server-side rendered, improving performance and reducing the client bundle size.